### PR TITLE
gzip compress event payload

### DIFF
--- a/Src/LibHoney.Tests/HttpTestServer.cs
+++ b/Src/LibHoney.Tests/HttpTestServer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.IO;
+using System.IO.Compression;
 using System.Net;
 using System.Text;
 using System.Threading;
@@ -76,7 +77,8 @@ namespace Honeycomb.Tests
                 Thread.Sleep (timeout);
 
             // Save the payload
-            var reader = new StreamReader (request.InputStream);
+            var gzipStream = new GZipStream(request.InputStream, CompressionMode.Decompress);
+            var reader = new StreamReader (gzipStream);
             payloadItems.Add (reader.ReadToEnd ());
             headers.Add (request.Headers);
 


### PR DESCRIPTION
Always send the requests gzipped (we could be good citizens and check `Accept-Encoding`, but everything else assumes compressed.)

Need to uncompress them in the test server (which thankfully forms an end-to-end check for the compression, :tada:)