### PR TITLE
Expose the responses through a class preventing additions.

### DIFF
--- a/Src/LibHoney.Tests/HoneyTest.cs
+++ b/Src/LibHoney.Tests/HoneyTest.cs
@@ -266,7 +266,8 @@ namespace Honeycomb.Tests
             Assert.Equal (true, libHoney.Transmission != null);
             Assert.Equal (true, libHoney.Responses != null);
             Assert.Equal (libHoney.Transmission.Responses, libHoney.Responses);
-            Assert.Equal (true, libHoney.Responses.BoundedCapacity > 1);
+
+            Assert.Equal (true, libHoney.Transmission.Responses.BoundedCapacity > 1);
         }
 
         [Fact]

--- a/Src/LibHoney.Tests/LibHoney.Tests.csproj
+++ b/Src/LibHoney.Tests/LibHoney.Tests.csproj
@@ -52,6 +52,7 @@
     <Compile Include="TransmissionTest.cs" />
     <Compile Include="HttpTestServer.cs" />
     <Compile Include="LibHoneyFixture.cs" />
+    <Compile Include="ResponseCollectionTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Src/LibHoney.Tests/ResponseCollectionTest.cs
+++ b/Src/LibHoney.Tests/ResponseCollectionTest.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Concurrent;
+using Xunit;
+
+namespace Honeycomb.Tests
+{
+    public class ResponseCollectionTest
+    {
+        [Fact]
+        public void Wrap ()
+        {
+            var responses = new BlockingCollection<Response> ();
+            responses.Add (new Response ());
+            responses.Add (null);
+
+            var coll = new ResponseCollection (responses);
+            Assert.Equal (coll.Responses, responses);
+            Assert.Equal (coll.Count, 2);
+            Assert.False (coll.IsAddingCompleted);
+            Assert.False (coll.IsCompleted);
+
+            responses.CompleteAdding ();
+            Assert.True (coll.IsAddingCompleted);
+            Assert.False (coll.IsCompleted);
+
+            responses.Take ();
+            responses.Take ();
+            Assert.True (coll.IsAddingCompleted);
+            Assert.True (coll.IsCompleted);
+        }
+
+        [Fact]
+        public void Consume ()
+        {
+            var responses = new BlockingCollection<Response> ();
+            responses.Add (null);
+            responses.Add (null);
+
+            var coll = new ResponseCollection (responses);
+
+            Response response1, response2;
+            response1 = coll.Take ();
+            coll.TryTake (out response2);
+
+            Assert.Null (response1);
+            Assert.Null (response2);
+            Assert.False (coll.IsAddingCompleted);
+            Assert.False (coll.IsCompleted);
+            Assert.Equal (coll.Count, 0);
+        }
+
+        [Fact]
+        public void Enumerate ()
+        {
+            var responses = new BlockingCollection<Response> ();
+            for (int i = 0; i < 5; i++)
+                responses.Add (null);
+
+            var coll = new ResponseCollection (responses);
+
+            int count = 0;
+            foreach (var response in coll) {
+                count++;
+                Assert.Null (response);
+            }
+
+            Assert.Equal (count, 5);
+            Assert.Equal (coll.Count, 5);
+        }
+    }
+}

--- a/Src/LibHoney/Event.cs
+++ b/Src/LibHoney/Event.cs
@@ -159,7 +159,7 @@ namespace Honeycomb
 
         void SendDroppedResponse ()
         {
-            libHoney.Responses.Add (new Response () {
+            libHoney.Transmission.EnqueueResponse (new Response () {
                 Metadata = Metadata,
                 ErrorMessage = "Event dropped due to sampling"
             });

--- a/Src/LibHoney/LibHoney.cs
+++ b/Src/LibHoney/LibHoney.cs
@@ -16,7 +16,7 @@ namespace Honeycomb
         readonly FieldHolder fields = new FieldHolder ();
 
         Transmission transmission;
-        BlockingCollection<Response> responses;
+        ResponseCollection responses;
 
         public LibHoney (string writeKey, string dataSet)
             : this (writeKey, dataSet, DefaultApiHost, DefaultSampleRate, DefaultMaxConcurrentBatches,
@@ -56,7 +56,7 @@ namespace Honeycomb
                 throw new ArgumentException (nameof (apiHost));
 
             transmission = new Transmission (maxConcurrentBatches, blockOnSend, blockOnResponse);
-            responses = transmission.Responses;
+            responses = new ResponseCollection (transmission.Responses);
 
             WriteKey = writeKey;
             DataSet = dataSet;
@@ -105,7 +105,7 @@ namespace Honeycomb
             get { return transmission == null; }
         }
 
-        public BlockingCollection<Response> Responses {
+        public ResponseCollection Responses {
             get {
                 return responses;
             }

--- a/Src/LibHoney/LibHoney.csproj
+++ b/Src/LibHoney/LibHoney.csproj
@@ -42,6 +42,7 @@
     <Compile Include="SendException.cs" />
     <Compile Include="Transmission.cs" />
     <Compile Include="Response.cs" />
+    <Compile Include="ResponseCollection.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Src/LibHoney/ResponseCollection.cs
+++ b/Src/LibHoney/ResponseCollection.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Concurrent;
+
+namespace Honeycomb
+{
+    public sealed class ResponseCollection : IEnumerable<Response>
+    {
+        BlockingCollection<Response> responses;
+
+        internal ResponseCollection (BlockingCollection<Response> responses)
+        {
+            this.responses = responses;
+        }
+
+        internal BlockingCollection<Response> Responses {
+            get { return responses; }
+        }
+
+        public int Count {
+            get { return responses.Count; }
+        }
+
+        public bool IsAddingCompleted {
+            get { return responses.IsAddingCompleted; }
+        }
+
+        public bool IsCompleted {
+            get { return responses.IsCompleted; }
+        }
+
+        public Response Take ()
+        {
+            return responses.Take ();
+        }
+
+        public bool TryTake (out Response response)
+        {
+            return responses.TryTake (out response);
+        }
+
+        public bool TryTake (out Response response, TimeSpan timeout)
+        {
+            return responses.TryTake (out response, timeout);
+        }
+
+        IEnumerator IEnumerable.GetEnumerator ()
+        {
+            return ((IEnumerable)responses).GetEnumerator ();
+        }
+
+        IEnumerator<Response> IEnumerable<Response>.GetEnumerator ()
+        {
+            return ((IEnumerable<Response>)responses).GetEnumerator ();
+        }
+    }
+}

--- a/Src/LibHoney/Transmission.cs
+++ b/Src/LibHoney/Transmission.cs
@@ -131,6 +131,14 @@ namespace Honeycomb
             client.Dispose ();
         }
 
+        public void EnqueueResponse (Response res)
+        {
+            if (BlockOnResponse)
+                responses.Add (res);
+            else
+                responses.TryAdd (res);
+        }
+
         public void Send (Event ev)
         {
             ev = ev.Clone (); // Prevent further changes
@@ -148,14 +156,6 @@ namespace Honeycomb
                 };
                 EnqueueResponse (res);
             }
-        }
-
-        void EnqueueResponse (Response res)
-        {
-            if (BlockOnResponse)
-                responses.Add (res);
-            else
-                responses.TryAdd (res);
         }
 
         void DoSend (Event ev)


### PR DESCRIPTION
The user should be able to consume such blocking collection,
without being able to put responses there.