### PR TITLE
Add ApiHost to Builder.

### DIFF
--- a/Src/LibHoney.Tests/BuilderTest.cs
+++ b/Src/LibHoney.Tests/BuilderTest.cs
@@ -150,15 +150,17 @@ namespace Honeycomb.Tests
             var honey = GetLibHoney ();
 
             var b = new Builder (honey);
-            Assert.Equal (honey.WriteKey, b.WriteKey);
-            Assert.Equal (honey.DataSet, b.DataSet);
-            Assert.Equal (honey.SampleRate, b.SampleRate);
+            b.WriteKey = "aaa-bbb-ccc";
+            b.DataSet = "unknown";
+            b.ApiHost = "https://unknown";
+            b.SampleRate = 5;
 
             var clone = b.Clone ();
-            Assert.Equal (true, clone != null);
-            Assert.Equal (b.WriteKey, clone.WriteKey);
-            Assert.Equal (b.DataSet, clone.DataSet);
-            Assert.Equal (b.SampleRate, clone.SampleRate);
+            Assert.NotSame (b, clone);
+            Assert.Equal ("aaa-bbb-ccc", clone.WriteKey);
+            Assert.Equal ("unknown", clone.DataSet);
+            Assert.Equal ("https://unknown", clone.ApiHost);
+            Assert.Equal (5, clone.SampleRate);
         }
 
         [Fact]
@@ -182,15 +184,16 @@ namespace Honeycomb.Tests
 
             var b = new Builder (honey);
             b.WriteKey = "aaa-bbb-ccc";
-            b.SampleRate = 5;
             b.DataSet = "unknown";
+            b.ApiHost = "https://unknown";
+            b.SampleRate = 5;
 
             var ev = b.NewEvent ();
-            Assert.Equal (true, ev != null);
-            Assert.Equal (b.WriteKey, ev.WriteKey);
-            Assert.Equal (b.DataSet, ev.DataSet);
-            Assert.Equal (b.SampleRate, ev.SampleRate);
-            Assert.Equal (honey.ApiHost, ev.ApiHost);
+            Assert.NotNull (ev);
+            Assert.Equal ("aaa-bbb-ccc", ev.WriteKey);
+            Assert.Equal ("unknown", ev.DataSet);
+            Assert.Equal ("https://unknown", ev.ApiHost);
+            Assert.Equal (5, ev.SampleRate);
         }
 
         [Fact]

--- a/Src/LibHoney/Builder.cs
+++ b/Src/LibHoney/Builder.cs
@@ -51,7 +51,17 @@ namespace Honeycomb
             // Stash these values away for Send()
             WriteKey = libHoney.WriteKey;
             DataSet = libHoney.DataSet;
+            ApiHost = libHoney.ApiHost;
             SampleRate = libHoney.SampleRate;
+        }
+
+        /// <summary>
+        /// Hostname for the Honeycomb API server to which to send events.
+        /// </summary>
+        /// <value>The API hostname.</value>
+        public string ApiHost {
+            get;
+            set;
         }
 
         /// <summary>
@@ -136,6 +146,7 @@ namespace Honeycomb
             builder.fields.Add (fields);
             builder.WriteKey = WriteKey;
             builder.DataSet = DataSet;
+            builder.ApiHost = ApiHost;
             builder.SampleRate = SampleRate;
             return builder;
         }
@@ -147,7 +158,7 @@ namespace Honeycomb
         /// <returns>The event.</returns>
         public Event NewEvent ()
         {
-            return new Event (libHoney, fields, WriteKey, DataSet, SampleRate);
+            return new Event (libHoney, fields, WriteKey, DataSet, ApiHost, SampleRate);
         }
 
         /// <summary>

--- a/Src/LibHoney/Event.cs
+++ b/Src/LibHoney/Event.cs
@@ -62,11 +62,12 @@ namespace Honeycomb
             SampleRate = libHoney.SampleRate;
         }
 
-        internal Event (LibHoney libHoney, FieldHolder fh, string writeKey, string dataSet, int sampleRate)
+        internal Event (LibHoney libHoney, FieldHolder fh, string writeKey, string dataSet, string apiHost, int sampleRate)
             : this (libHoney, fh.Fields, fh.DynamicFields)
         {
             WriteKey = writeKey;
             DataSet = dataSet;
+            ApiHost = apiHost;
             SampleRate = sampleRate;
         }
 


### PR DESCRIPTION
Even though the Python connector lacks this
for Builder, the Go connector *has* it, so do that too.